### PR TITLE
fix: prettier endOfLine

### DIFF
--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,3 +1,4 @@
 {
-  "singleQuote": true
+  "singleQuote": true,
+  "endOfLine": "auto"
 }


### PR DESCRIPTION
fix error: Delete `␍`eslint[prettier/prettier]